### PR TITLE
Update Citect.CtApi.csproj, Remove fixed path

### DIFF
--- a/Citect.CtApi/Citect.CtApi/Citect.CtApi.csproj
+++ b/Citect.CtApi/Citect.CtApi/Citect.CtApi.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Users\gestrade\Source\Repos\citect\Citect.CtApi\Citect.CtApi\Citect.CtApi.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed path causing Visual Studio build to fail, as the path is not available